### PR TITLE
add type module to import im package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.6",
   "description": "React Carousel.",
   "main": "dist/index.js",
+  "type": "module",
   "module": "dist/index.js",
   "files": [
     "dist/*"


### PR DESCRIPTION
Hey, thanks for your package, I had to had this line in my package.json cause I constantly had an error "Cannot use import statement outside a module" when I want to import like in your example for my nextjs app.
It's a little add who could probably help. :)